### PR TITLE
Consolidates all build directories into a single parent 'build' direc…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ all:	$(TARGETS) sizes
 clean:
 	cd libopencm3 && make --no-print-directory clean && cd ..
 	rm -f *.elf *.bin # Remove any elf or bin files contained directly in the Bootloader directory
-	rm -rf build_* # Remove build directories
+	rm -rf build # Remove build directories
 
 #
 # Specific bootloader targets.
@@ -126,14 +126,14 @@ aerofcv1_bl: $(MAKEFILE_LIST) $(LIBOPENCM3)
 #
 .PHONY: sizes
 sizes:
-	@-find build_* -name '*.elf' -type f | xargs size 2> /dev/null || :
+	@-find build/*/ -name '*.elf' -type f | xargs size 2> /dev/null || :
 
 #
 # Binary management
 #
 .PHONY: deploy
 deploy:
-	zip -j Bootloader.zip build_*/*.bin
+	zip -j Bootloader.zip build/*/*.bin
 
 #
 # Submodule management

--- a/rules.mk
+++ b/rules.mk
@@ -2,7 +2,7 @@
 # Common rules for makefiles for the PX4 bootloaders
 #
 
-BUILD_DIR	 = build_$(TARGET_FILE_NAME)
+BUILD_DIR	 = build/$(TARGET_FILE_NAME)
 
 OBJS		:= $(addprefix $(BUILD_DIR)/, $(patsubst %.c,%.o,$(SRCS)))
 DEPS		:= $(OBJS:.o=.d)
@@ -19,7 +19,7 @@ $(BUILD_DIR)/%.o:	%.c
 
 # Make the build directory
 $(BUILD_DIR):
-	mkdir $(BUILD_DIR)
+	mkdir -p $(BUILD_DIR)
 
 $(ELF):		$(OBJS) $(MAKEFILE_LIST)
 	$(CC) -o $@ $(OBJS) $(FLAGS)


### PR DESCRIPTION
…tory (#98)

All individual board build directories are now generated in a consolidating
'build' directory (Bootloader/build).

This helps remove the clutter of having multiple board build directories
generated in the src directory.